### PR TITLE
Update for pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,11 @@ classifiers = [
 [project.urls]
 Homepage = "https://ucl-pond.github.io/kde_ebm"
 
-[tool.setuptools]
-packages = ["kde_ebm"]
+# [tool.setuptools]
+# packages = ["kde_ebm"]
 
-# [tool.setuptools.packages.find]
-# where = ["."]
+[tool.setuptools.packages.find]
+where = ["."]
 
 ### Include synthetic data
 [tool.setuptools.package-data]


### PR DESCRIPTION
I recently tried to install the package to work through the tutorial (https://disease-progression-modelling.github.io/pages/notebooks/ebm/T1_kde_ebm_walkthrough.html) and it was failing with import errors. Made this change to the packaging specification and then it could install via pip directly from the github link.